### PR TITLE
Introduction to a new feature of custom themes.

### DIFF
--- a/src/js/components/App.vue
+++ b/src/js/components/App.vue
@@ -276,7 +276,7 @@ export default {
 
         themes: [
             'grey', 'red', 'orange', 'yellow', 'green',
-            'teal', 'blue', 'indigo', 'purple', 'pink',
+            'teal', 'blue', 'indigo', 'purple', 'pink', 'blood',
         ],
 
         theme: 'purple',

--- a/src/sass/_customThemes.scss
+++ b/src/sass/_customThemes.scss
@@ -1,0 +1,67 @@
+// Custom Themes
+
+// Blood
+.app-color-blood {
+	// Set the colors for Blood theme
+    .bg-primary { background-color: black }
+    .border-primary { border-color: red }
+    .text-primary { color: red }
+
+    @each $ton in $tons {
+        .bg-primary-#{$ton} { background-color: black }
+        .border-primary-#{$ton} { border-color: red }
+        .text-primary-#{$ton} { color: red }
+    }
+
+    .newtab__item_body { background-color: #1a1a1a }
+	.newtab__subtitle { color: #8B0000 }
+
+    // Background Image
+    .newtab {
+	    background-color: transparent;
+	    background-image: url("https://d1u5p3l4wpay3k.cloudfront.net/dota2_gamepedia/5/56/Feast_of_Abscession_Preview_7.jpg");
+	    background-repeat: no-repeat;
+	    background-attachment: fixed;
+	    background-position: center;
+	    background-size: cover;
+	}
+
+	// Blood drop
+	.newtab__title {
+		color: #4D0000;
+		&:after{
+			display:block;
+			content:"";
+			background:#8B0000;
+			width:18px;
+			height:18px;
+			position:absolute;
+			left:28px;
+			animation: drop 7s ease infinite;
+			border-radius: 50%;
+			transform:scale(0.7,1) rotate(45deg);
+			box-shadow: 1px 1px 5px red;
+			margin-top: 12px;
+		}
+	}
+	@-webkit-keyframes drop {
+		0%{
+			transform:scale(0.1,0.1) rotate(45deg);
+			top:25px;
+			border-top-left-radius: 50%;
+		}
+		90%{
+			top:42px;
+			border-top-left-radius: 0;
+		}
+		95%{
+			border-top-left-radius: 0;
+			transform:scale(0.7,1) rotate(45deg);
+		}
+		100%{
+			top:385px;
+			border-top-left-radius: 50%;
+			transform:scale(2,0.7) rotate(45deg);
+		}
+	}
+}

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -31,3 +31,6 @@ $tons: (
         }
     }
 }
+
+// Custom Themes
+@import 'customThemes';


### PR DESCRIPTION
I'm making a custom theme feature and want to know what it's the best approach, for now i add _customTheme.scss file, import it at app.scss and add a new theme called blood at the App.vue, so the user can change to that theme in the drop-down.

The goal may be add a custom button at the top to import custom SCSS or add a category to people browse custom themes made by the community.

![screen shot 2018-08-08 at 17 17 07](https://user-images.githubusercontent.com/15040050/43861988-ea8a449c-9b2e-11e8-8d53-c01a905246a7.png)
